### PR TITLE
Improve expanding templates for blank lines

### DIFF
--- a/autoload/sonictemplate.vim
+++ b/autoload/sonictemplate.vim
@@ -112,7 +112,7 @@ function! sonictemplate#apply(name, mode) abort
     if line =~ '^\s*$' && line('.') != line('$')
       silent! normal dd
     endif
-    let c = indent . substitute(c, "\n", "\n".indent, 'g')
+    let c = indent . substitute(substitute(c, "\n", "\n".indent, 'g'), "\n".indent."\n", "\n\n", 'g')
     if len(indent) && (&expandtab || &tabstop != &shiftwidth || indent =~ '^ \+$')
       let c = substitute(c, "\t", repeat(' ', min([len(indent), &shiftwidth])), 'g')
     endif


### PR DESCRIPTION
テンプレートを反映する際、テンプレート内にある空行に対して変数のindentを行の先頭に付けないようにしました。

うまい正規表現が思いつかなかったので、一度置換処理したものにまた置換をかけているのでスマートな方法があったらお願いします。
