### PR TITLE
fix template for flake8

### DIFF
--- a/template/python/base-class.py
+++ b/template/python/base-class.py
@@ -2,6 +2,7 @@
 {{_name_}}
 """
 
+
 class {{_expr_:substitute('{{_input_:name}}', '\w\+', '\u\0', '')}}(object):
 	def __init__(self{{_cursor_}}):
 

--- a/template/python/base-main.py
+++ b/template/python/base-main.py
@@ -1,5 +1,6 @@
 # vim: fileencoding=utf-8
 
+
 def main():
 	{{_cursor_}}
 

--- a/template/python/base-test.py
+++ b/template/python/base-test.py
@@ -4,6 +4,7 @@
 
 import unittest
 
+
 class {{_expr_:substitute('{{_input_:name}}', '\w\+', '\u\0', '')}}(unittest.TestCase):
     def setUp(self):
         pass


### PR DESCRIPTION
flake8というPythonのコードチェッカの中で利用しているPEP8というCoding Style Guideでは空行のあけ方にも規定があります。
http://legacy.python.org/dev/peps/pep-0008/#blank-lines

それに従っていなかったので空行をつけました。
よろしくお願いします。
