### PR TITLE
Fix for noexpandtab && &sw == 0 && &ts != &sw

### DIFF
--- a/autoload/sonictemplate.vim
+++ b/autoload/sonictemplate.vim
@@ -266,7 +266,7 @@ function! sonictemplate#apply(name, mode, ...) abort
 
   if !buffer_is_not_empty
     let c = substitute(c, '{{_inline_}}\s*', '', 'g')
-    if &expandtab || &tabstop != &shiftwidth
+    if &expandtab || (&shiftwidth && &tabstop != &shiftwidth)
       let c = substitute(c, "\t", repeat(' ', &shiftwidth), 'g')
     endif
     silent! %d _
@@ -291,9 +291,9 @@ function! sonictemplate#apply(name, mode, ...) abort
         let c = lhs . c . rhs
       endif
       let c = indent . substitute(substitute(c, "\n", "\n".indent, 'g'), "\n".indent."\n", "\n\n", 'g')
-      if len(indent) && (&expandtab || &tabstop != &shiftwidth || indent =~ '^ \+$')
+      if len(indent) && (&expandtab || (&shiftwidth && &tabstop != &shiftwidth) || indent =~ '^ \+$')
         let c = substitute(c, "\t", repeat(' ', min([len(indent), &shiftwidth])), 'g')
-      elseif &expandtab || &tabstop != &shiftwidth
+      elseif &expandtab || (&shiftwidth && &tabstop != &shiftwidth)
         let c = substitute(c, "\t", repeat(' ', &shiftwidth), 'g')
       endif
       if line('.') < line('$')


### PR DESCRIPTION
http://vim-jp.org/vimdoc-ja/options.html#'shiftwidth'
>   0 の場合は、'ts' の値が使われる。実際に使われる値を取得するには
        |shiftwidth()| 関数を使う。

上記 `&shiftwidth == 0` の挙動を想定して `set sw=0` していると、適切にインデントできない件を修正しました。
