### PR TITLE
fix rust main template

### DIFF
--- a/template/rust/base-main.rs
+++ b/template/rust/base-main.rs
@@ -1,5 +1,3 @@
-use std;
-
-fn main(args:[str]) {
+fn main() {
 	{{_cursor_}}
 }


### PR DESCRIPTION
- `std` crate is available by default
- main function does not take arguments any more