### PR TITLE
Fix missing backslash escape at postfix and add some postfix patterns

### DIFF
--- a/autoload/sonictemplate.vim
+++ b/autoload/sonictemplate.vim
@@ -340,7 +340,7 @@ function! sonictemplate#postfix()
     return ''
   endif
   let line = getline('.')[:col('.')]
-  let line = escape(line, '\')
+  let line = escape(line, '\&')
   for k in keys(s:pat[s:get_raw_filetype()])
     let m = matchstr(line, k)
     if len(m) > 0

--- a/autoload/sonictemplate.vim
+++ b/autoload/sonictemplate.vim
@@ -336,6 +336,7 @@ function! sonictemplate#postfix()
     return ''
   endif
   let line = getline('.')[:col('.')]
+  let line = escape(line, '\')
   for k in keys(s:pat[&ft])
     let m = matchstr(line, k)
     if len(m) > 0

--- a/template/go/pattern.stpl
+++ b/template/go/pattern.stpl
@@ -23,3 +23,36 @@
 
 \(\S\+\)\.query$
 	{{$1}}.Query("{{_cursor_}}")
+
+\(\S.*\)\.pr\%[int]$
+	fmt.Print({{$1}})
+	{{_cursor_}}
+
+\(\S.*\)\.pr\%[int]f$
+	fmt.Printf({{$1}})
+	{{_cursor_}}
+
+\(\S.*\)\.pr\%[int]l\%[n]$
+	fmt.Println({{$1}})
+	{{_cursor_}}
+
+\(\S.*\)\.fpr\%[int]$
+	fmt.Fprint({{$1}})
+	{{_cursor_}}
+
+\(\S.*\)\.fpr\%[int]f$
+	fmt.Fprintf({{$1}})
+	{{_cursor_}}
+
+\(\S.*\)\.fpr\%[int]l\%[n]$
+	fmt.Fprintln({{$1}})
+	{{_cursor_}}
+
+\(\S.*\)\.spr\%[int]$
+	{{_cursor_}} fmt.Sprint({{$1}})
+
+\(\S.*\)\.spr\%[int]f$
+	{{_cursor_}} fmt.Sprintf({{$1}})
+
+\(\S.*\)\.spr\%[int]l\%[n]$
+	{{_cursor_}} fmt.Sprintln({{$1}})

--- a/template/java/pattern.stpl
+++ b/template/java/pattern.stpl
@@ -1,0 +1,11 @@
+\(\S.*\)\.pr\%[int]$
+	System.out.print({{$1}});
+	{{_cursor_}}
+
+\(\S.*\)\.pr\%[int]f$
+	System.out.printf({{$1}});
+	{{_cursor_}}
+
+\(\S.*\)\.pr\%[int]l\%[n]$
+	System.out.println({{$1}});
+	{{_cursor_}}


### PR DESCRIPTION
When writing in Go, type the following code,

```go
"AA\nBB".log
```

and hits `<C-y><C-b>`, then got the following result.

```go
log.Println("AA
BB")

```

but want this.

```go
log.Println("AA\nBB")

```

This PR fixes this.