### PR TITLE
using '\b' for elase

### DIFF
--- a/autoload/sonictemplate.vim
+++ b/autoload/sonictemplate.vim
@@ -327,7 +327,7 @@ function! sonictemplate#apply(name, mode, ...) abort
     else
       silent! call search('{{_cursor_}}\zs', 'w')
       silent! foldopen
-      silent! call feedkeys(repeat("\<bs>", 12), 'n')
+      silent! call feedkeys(repeat("\b", 12))
     endif
   endif
 endfunction
@@ -379,7 +379,7 @@ function! sonictemplate#postfix()
       if stridx(c, '{{_cursor_}}') != -1
         silent! call search('{{_cursor_}}\zs', 'w')
         silent! foldopen
-        silent! call feedkeys(repeat("\<bs>", 12))
+        silent! call feedkeys(repeat("\b", 12))
       endif
       break
     endif


### PR DESCRIPTION
`{{_cursor_}}` was not elase when with vim option `inoremap <BS>  <Nop>` .
Use `\b` for feedkeys, it works correct.

Please fix it or marge this request.