### PR TITLE
Expose template file resolution as sonictemplate#find_template_file()

### DIFF
--- a/autoload/sonictemplate.vim
+++ b/autoload/sonictemplate.vim
@@ -414,9 +414,8 @@ function! s:insert_into_buffer(c) abort
   return l:c
 endfunction
 
-function! sonictemplate#apply(name, mode, ...) abort
+function! s:resolve_template_files(name, mode, intelligent) abort
   let l:name = matchstr(a:name, '\S\+')
-  let l:buffer_is_not_empty = search('[^ \t]', 'wn')
   if a:mode =~# '[vV]'
     let l:prefix = 'wrap'
   else
@@ -427,7 +426,7 @@ function! sonictemplate#apply(name, mode, ...) abort
   endif
   let l:ft = s:getopt('filetype')
   if l:ft ==# ''
-    if get(a:000, 0, 0)
+    if a:intelligent
       let l:fts = [sonictemplate#get_filetype(), s:get_raw_filetype(), s:get_filetype(), '_']
     else
       let l:fts = [s:get_raw_filetype(), s:get_filetype(), sonictemplate#get_filetype(), '_']
@@ -435,7 +434,18 @@ function! sonictemplate#apply(name, mode, ...) abort
   else
     let l:fts = [l:ft]
   endif
-  let l:fs = s:find_template_file(l:name, l:prefix, l:fts)
+  return s:find_template_file(l:name, l:prefix, l:fts)
+endfunction
+
+function! sonictemplate#find_template_file(name, mode, ...) abort
+  let l:fs = s:resolve_template_files(a:name, a:mode, get(a:000, 0, 0))
+  return empty(l:fs) ? '' : l:fs[0]
+endfunction
+
+function! sonictemplate#apply(name, mode, ...) abort
+  let l:name = matchstr(a:name, '\S\+')
+  let l:buffer_is_not_empty = search('[^ \t]', 'wn')
+  let l:fs = s:resolve_template_files(a:name, a:mode, get(a:000, 0, 0))
   if empty(l:fs)
     echomsg 'Template ' . l:name . ' is not exists.'
     return


### PR DESCRIPTION
## Summary

Adds a public function, `sonictemplate#find_template_file(name, mode, ...)`, that resolves a template `name` to the file path `sonictemplate#apply()` would expand, without applying it.

The prefix/filetype resolution logic previously inlined in `sonictemplate#apply()` is factored out into a shared helper (`s:resolve_template_files`), so both functions stay in sync by construction. `sonictemplate#apply()`'s behavior is unchanged.

## Motivation

External pickers that list template names (e.g. a ddu.vim source) currently have no way to preview which file a name resolves to, short of duplicating the internal prefix/filetype/tmpldir search logic. Exposing this resolution as a small, side-effect-free function lets such integrations show a real preview.

## Test plan

- [x] `sonictemplate#apply()` still expands templates correctly (base/snip/wrap, variable substitution, cursor placement) — manually verified across C, Python and other filetypes.
- [x] `sonictemplate#find_template_file()` returns the same file `sonictemplate#apply()` would use, verified via https://github.com/yoshphys/ddu-source-sonictemplate (a ddu.vim source built on top of this function for template preview + expansion).